### PR TITLE
Friendship2

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,28 +1,49 @@
 class InvitationsController < ApplicationController
   def create
-    invitation = Invitation.new(user_id: params[:user], friend_id: params[:friend], confirmed: false)
-    if invitation.save
-      redirect_to User.find(invitation.friend_id),
+    invitations = [Invitation.new(user_id: params[:user],
+                                  friend_id: params[:friend],
+                                  confirmed: false,
+                                  inviter_id: params[:user]),
+                   Invitation.new(user_id: params[:friend],
+                                  friend_id: params[:user],
+                                  confirmed: false,
+                                  inviter_id: params[:user])]
+    if invitations.all?(&:save)
+      redirect_to User.find(invitations[0].friend_id),
                   notice: 'Your friendship invitation was successfully sent.'
     else
-      render
+      render :back, alert: invitations.reduce do |acc, inv|
+        acc + inv.errors.full_messages
+      end
     end
   end
 
+  ## Accepting the invitation
   def update
-    invitation = Invitation.find(params[:id])
-    user = User.find(invitation.user_id)
-    invitation.confirmed = true
-    if invitation.save
-      redirect_to user, notice: "You are now friends with #{user.name}!"
+    invitations = fetch_invitations(params[:id])
+    invitations.each { |inv| inv.confirmed = true }
+
+    if invitations.all?(&:save)
+      redirect_to user, notice: 'You now have one more friend!'
     else
-      render current_user
+      render current_user, alert: invitations.reduce do |acc, inv|
+        acc + inv.errors.full_messages
+      end
     end
   end
 
   def destroy
-    invitation = Invitation.find(params[:id])
-    invitation.destroy
+    invitations = fetch_invitations(params[:id])
+    invitations.each(&:destroy)
     redirect_to current_user, notice: 'Invitation successfully rejected.'
+  end
+
+  private
+
+  def fetch_invitations(example_id)
+    from_invitation = Invitation.find(example_id)
+    from_id = from_invitation.user_id
+    to_id = from_invitation.friend_id
+    Invitation.between(from_id, to_id)
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -23,8 +23,9 @@ class InvitationsController < ApplicationController
     invitations = fetch_invitations(params[:id])
     invitations.each { |inv| inv.confirmed = true }
 
+    user = User.find(Invitation.find(params[:id]).inviter_id)
     if invitations.all?(&:save)
-      redirect_to user, notice: 'You now have one more friend!'
+      redirect_to user, notice: "You are now friends with #{user.name}!"
     else
       render current_user, alert: invitations.reduce do |acc, inv|
         acc + inv.errors.full_messages

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
 
   def index
     @post = Post.new
-    timeline_posts
+    timeline_posts(current_user)
   end
 
   def create
@@ -12,19 +12,15 @@ class PostsController < ApplicationController
     if @post.save
       redirect_to posts_path, notice: 'Post was successfully created.'
     else
-      timeline_posts
+      timeline_posts(current_user)
       render :index, alert: 'Post was not created.'
     end
   end
 
   private
 
-  def timeline_posts
-    relevant_posts = current_user.posts.select(&:created_at)
-    current_user.friends.includes(:posts).each do |friend|
-      relevant_posts += friend.posts
-    end
-    @timeline_posts = relevant_posts.sort { |p1, p2| p2.created_at <=> p1.created_at }
+  def timeline_posts(user)
+    @timeline_posts = user.relevant_posts
   end
 
   def post_params

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,6 +1,8 @@
 class Invitation < ApplicationRecord
   belongs_to :user
   belongs_to :friend, class_name: 'User'
+  belongs_to :inviter, class_name: 'User'
 
   validates :user_id, uniqueness: { scope: :friend_id, message: 'You have already sent a request to this user' }
+  validates :inviter_id, presence: true
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -5,4 +5,9 @@ class Invitation < ApplicationRecord
 
   validates :user_id, uniqueness: { scope: :friend_id, message: 'You have already sent a request to this user' }
   validates :inviter_id, presence: true
+
+  scope :between, lambda { |user_id, friend_id|
+                    where('user_id = ? and friend_id = ?', user_id, friend_id)
+                      .or(where('user_id = ? and friend_id = ?', friend_id, user_id))
+                  }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,15 +18,13 @@ class User < ApplicationRecord
            class_name: 'Invitation'
   has_many :friends, through: :invitations_confirmed, source: :friend
 
-  has_many :pending_invitations, -> { where confirmed: false },
-           class_name: 'invitation', foreign_key: 'friend_id'
+  has_many :pending_invitations,
+           ->(user) { where(confirmed: false).where.not(inviter_id: user.id) },
+           class_name: 'Invitation', foreign_key: 'friend_id'
 
-  def friend_with?(user)
-    invitation.confirmed_record?(id, user.id)
-  end
-
-  def pending_invitations
-    Invitation.where(friend_id: id, confirmed: false)
+  def relevant_posts
+    ids = self.friends.pluck(:id) << self.id
+    Post.where(user_id: ids).ordered_by_most_recent
   end
 
   def invitable?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
            class_name: 'Invitation', foreign_key: 'friend_id'
 
   def relevant_posts
-    ids = self.friends.pluck(:id) << self.id
+    ids = friends.pluck(:id) << id
     Post.where(user_id: ids).ordered_by_most_recent
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,25 +14,12 @@ class User < ApplicationRecord
 
   has_many :invitations, dependent: :destroy
 
-  has_many :invitations_sent_confirmed, -> { where confirmed: true },
+  has_many :invitations_confirmed, -> { where confirmed: true },
            class_name: 'Invitation'
-  has_many :invited_friends, through: :invitations_sent_confirmed,
-                             source: :friend, class_name: 'User'
+  has_many :friends, through: :invitations_confirmed, source: :friend
 
   has_many :pending_invitations, -> { where confirmed: false },
            class_name: 'invitation', foreign_key: 'friend_id'
-  has_many :invitations_received_confirmed, -> { where confirmed: true },
-           class_name: 'Invitation', foreign_key: 'friend_id'
-  has_many :inviter_friends, through: :invitations_received_confirmed,
-                             source: :user, class_name: 'User'
-
-  def friends
-    friends_sent_invitation = Invitation.where(user_id: id, confirmed: true).pluck(:friend_id)
-    friends_got_invitation = Invitation.where(friend_id: id, confirmed: true).pluck(:user_id)
-
-    ids = friends_sent_invitation + friends_got_invitation
-    User.where(id: ids)
-  end
 
   def friend_with?(user)
     invitation.confirmed_record?(id, user.id)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
     <%= link_to 'Sign in', user_session_path %>
     <% end %>
     <% if user_signed_in?%>
-    <%= link_to current_user.name, current_user %>
+    <%= link_to current_user.name, current_user, id: 'my-profile' %>
     <%end%>
   </nav>
   <% if notice.present? %>

--- a/db/migrate/20210714152729_add_inviter_id_to_invitation.rb
+++ b/db/migrate/20210714152729_add_inviter_id_to_invitation.rb
@@ -1,0 +1,5 @@
+class AddInviterIdToInvitation < ActiveRecord::Migration[5.2]
+  def change
+    add_column :invitations, :inviter_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_11_134045) do
+ActiveRecord::Schema.define(version: 2021_07_14_152729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2021_07_11_134045) do
     t.boolean "confirmed", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "inviter_id", null: false
     t.index ["user_id"], name: "index_invitations_on_user_id"
   end
 

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Freature test' do
                          email: "user#{n + 1}@example.com",
                          password: '123456',
                          password_confirmation: '123456')
-      users[n+1] = user
+      users[n + 1] = user
     end
     users[1].posts.create(content: 'Hello world')
     create_invitation_pair(users[1], users[3], false)

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -1,7 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe 'Freature test' do
-  # Populate the database
+  def create_invitation_pair(inviter, invitee, confirmed)
+    Invitation.create(
+      user_id: inviter.id,
+      friend_id: invitee.id,
+      confirmed: confirmed,
+      inviter_id: inviter.id
+    )
+    Invitation.create(
+      user_id: invitee.id,
+      friend_id: inviter.id,
+      confirmed: confirmed,
+      inviter_id: inviter.id
+    )
+  end
+
   before :each do
     users = []
     4.times do |n|
@@ -9,13 +23,11 @@ RSpec.describe 'Freature test' do
                          email: "user#{n + 1}@example.com",
                          password: '123456',
                          password_confirmation: '123456')
-      users[n] = user
+      users[n+1] = user
     end
-    users[0].posts.create(content: 'Hello world')
-    users[0].invitations.create(friend_id: users[3].id,
-                                confirmed: true)
-    users[0].invitations.create(friend_id: users[2].id,
-                                confirmed: false)
+    users[1].posts.create(content: 'Hello world')
+    create_invitation_pair(users[1], users[3], false)
+    create_invitation_pair(users[1], users[4], true)
   end
 
   def login_process(user_number: 1)
@@ -110,8 +122,7 @@ RSpec.describe 'Freature test' do
 
     it 'can confirm received invitation' do
       login_process(user_number: 3)
-      visit '/users'
-      click_link 'User3'
+      click_link 'my-profile'
       click_link 'Accept Invitation'
       expect(page).to have_content 'You are now friends with'
     end
@@ -119,7 +130,7 @@ RSpec.describe 'Freature test' do
     it 'can reject received invitation' do
       login_process(user_number: 3)
       visit '/users'
-      click_link 'User3'
+      click_link 'my-profile'
       click_link 'Reject Invitation'
       expect(page).to have_content 'Invitation successfully rejected.'
     end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -12,17 +12,17 @@ end
 RSpec.describe Post, type: :model do
   before(:each) do
     users = []
-      5.times do |n|
-        user = User.create(name: "User#{n}",
-                           email: "user#{n}@example.com",
-                           password: '123456',
-                           password_confirmation: '123456')
-        users[n] = user
-      end
-      (1..4).each do |n|
-        new_invitation(users[0], users[n], n.even?, users[0]).save
-        new_invitation(users[n], users[0], n.even?, users[0]).save
-      end
+    5.times do |n|
+      user = User.create(name: "User#{n}",
+                         email: "user#{n}@example.com",
+                         password: '123456',
+                         password_confirmation: '123456')
+      users[n] = user
+    end
+    (1..4).each do |n|
+      new_invitation(users[0], users[n], n.even?, users[0]).save
+      new_invitation(users[n], users[0], n.even?, users[0]).save
+    end
   end
 
   describe 'Validations' do

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+def new_invitation(user, friend, confirmed, inviter)
+  Invitation.new(
+    user_id: user.id,
+    friend_id: friend.id,
+    confirmed: confirmed,
+    inviter_id: inviter.id
+  )
+end
+
+RSpec.describe Post, type: :model do
+  before(:each) do
+    users = []
+      5.times do |n|
+        user = User.create(name: "User#{n}",
+                           email: "user#{n}@example.com",
+                           password: '123456',
+                           password_confirmation: '123456')
+        users[n] = user
+      end
+      (1..4).each do |n|
+        new_invitation(users[0], users[n], n.even?, users[0]).save
+        new_invitation(users[n], users[0], n.even?, users[0]).save
+      end
+  end
+
+  describe 'Validations' do
+    it "Can't create more than one invitation with the same user and friend" do
+      user0 = User.find_by(name: 'User0')
+      user1 = User.find_by(name: 'User1')
+      repeated = new_invitation(user0, user1, false, user0)
+      expect(repeated.valid?).to be(false)
+    end
+  end
+
+  describe 'Scopes' do
+    it 'between fetches the correct invitations' do
+      user0_id = User.find_by(name: 'User0').id
+      user1_id = User.find_by(name: 'User1').id
+      scope_fetch = Invitation.between(user0_id, user1_id).to_a
+      p scope_fetch
+      manual_fetch = [Invitation.find_by(user_id: user0_id, friend_id: user1_id),
+                      Invitation.find_by(user_id: user1_id, friend_id: user0_id)]
+
+      expect(scope_fetch).to match_array(manual_fetch)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -98,8 +98,6 @@ RSpec.describe User, type: :model do
 
     it 'show posts relevant to User0' do
       user0 = User.find_by(name: 'User0')
-      user2 = User.find_by(name: 'User2')
-      user4 = User.find_by(name: 'User4')
 
       messages = ["Hello, I'm User4", "Hello, I'm User2", "Hello, I'm User0"]
       fetched_messages = user0.relevant_posts.map(&:content)


### PR DESCRIPTION
Pull request to modify the invitations model logic.
In this pull request we:
- [x] Added inviter_id field to the Invitation model, with migrations.
- [x] Changed InvitationController.create, .update, and .destroy to handle mutual friendships as pairs of invitations. If user1 invites another user, invitations with user1.id as user_id and with user1.id as friend_id are created and handled together.
- [x] Changed and update user associations to handle and take advantage of the new invitations logic.
- [x] Changed the SQL query for the posts shown on the timeline page to take advantage of the new model.
- [x] Update tests to handle the new logic. Add new tests to test the added methods.